### PR TITLE
fix: allowing to import the declaration files.

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "license": "MIT",
   "author": "Arvin Xu <arvinx@foxmail.com> (https://www.arvinx.com)",
-  "typings": "typings",
+  "types": "./typings/index.d.ts",
   "files": [
     "typings"
   ],

--- a/typings/InternalAPI.d.ts
+++ b/typings/InternalAPI.d.ts
@@ -1,3 +1,5 @@
+/// <reference path="appkit/index.d.ts" />
+
 // Internal API for full access to the Sketch Objective-C runtime
 
 // For a deeper integration with Sketch,

--- a/typings/Mocha.d.ts
+++ b/typings/Mocha.d.ts
@@ -1,3 +1,4 @@
+/// <reference path="appkit/index.d.ts" />
 /*
 ABOUT:
 The rest of this file are bare minimum types referenced in sketch.d.ts.

--- a/typings/SketchContext.d.ts
+++ b/typings/SketchContext.d.ts
@@ -1,3 +1,5 @@
+/// <reference path="./InternalAPI.d.ts" />
+
 declare interface SketchContext {
   api(): any;
   command: MSPluginCommand;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1,0 +1,3 @@
+/// <reference path="./InternalAPI.d.ts" />
+/// <reference path="./SketchContext.d.ts" />
+/// <reference path="./PublicAPI.d.ts" />


### PR DESCRIPTION
With this PR it should be possible to install `sketch-typings` and the only additional installation step would be to _somewhere_ (first line first file) add the `import 'sketch-typings'` declaration.

Before:
<img width="610" alt="Screen Shot 2020-08-30 at 18 21 54" src="https://user-images.githubusercontent.com/914122/91655715-b4d18480-eaed-11ea-9918-82014af89025.png">

After:
<img width="610" alt="Screen Shot 2020-08-30 at 18 21 27" src="https://user-images.githubusercontent.com/914122/91655718-b8fda200-eaed-11ea-9a57-90525cef64e8.png">
