### PR TITLE
fix: correcting property name from `fill` to `fillType`

### DIFF
--- a/typings/PublicAPI.d.ts
+++ b/typings/PublicAPI.d.ts
@@ -1641,7 +1641,7 @@ declare module 'sketch/dom' {
       /**
        * The type of the fill.
        */
-      fill: Style.FillType;
+      fillType: Style.FillType;
       /**
        * A rgba hex-string (#000000ff is opaque black).
        */
@@ -1675,7 +1675,7 @@ declare module 'sketch/dom' {
       /**
        * The type of the fill of the border.
        */
-      fill: Style.FillType;
+      fillType: Style.FillType;
       /**
        * A rgba hex-string (#000000ff is opaque black).
        */


### PR DESCRIPTION
In the [Sketch API docs](https://developer.sketch.com/reference/api/#fill) _(and my tests)_ the `fill` property is actually called `fillType`. This PR fixes this typo.