### PR TITLE
fix: Allowing for export API to support output = false | null | 0

### DIFF
--- a/typings/PublicAPI.d.ts
+++ b/typings/PublicAPI.d.ts
@@ -2151,9 +2151,10 @@ declare module 'sketch/dom' {
 
     export interface ExportOptions {
       /**
-       * this is the path of the folder where all exported files are placed (defaults to "~/Documents/Sketch Exports").
+       * This is the path of the folder where all exported files are placed (defaults to "~/Documents/Sketch Exports").
+       * If falsey, the data for the objects are returned immediately.
        */
-      output?: string;
+      output: string | false | null | 0;
       /**
        * Comma separated list of formats to export to (png, jpg, svg, json or pdf) (default to "png").
        */


### PR DESCRIPTION
As specified in the Skech API documentation [`export`](https://developer.sketch.com/reference/api/#export) will allow for `output` to be `false` or `0` in order to directly get the image instead of writing it to the filesystem.

This PR adds the false | 0 case and documents it.