### PR TITLE
fix: oops documentation typo

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -2,8 +2,8 @@
 
 Community built set of [typescript declarations][dec] for writing [Sketch plugins][sketch-api].
 
-- [dec]: https://www.typescriptlang.org/docs/handbook/declaration-files/introduction.html
-- [sketch-api]: https://developer.sketch.com/reference/api/
+[dec]: https://www.typescriptlang.org/docs/handbook/declaration-files/introduction.html
+[sketch-api]: https://developer.sketch.com/reference/api/
 
 ## Usage
 


### PR DESCRIPTION
Oops, seems like in #2 I mistook how github renders the linked links. 😅 