### PR TITLE
fix: Adding empty file to be imported

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "sketch-typings",
   "version": "0.1.1",
   "description": "Community built set of typescript declarations for writing Sketch plugins.",
+  "main": "index.js",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/arvinxx/sketch-typings.git"


### PR DESCRIPTION
If the package doesn't have a "main" entrypoint, a webpack builder might break. This PR adds an empty file to be imported.

Related to #3 