### PR TITLE
fix: allow construction of CurvePoints

### DIFF
--- a/typings/PublicAPI.d.ts
+++ b/typings/PublicAPI.d.ts
@@ -714,7 +714,7 @@ declare module 'sketch/dom' {
       /**
        * The points defining the Shape Path.
        */
-      points?: CurvePoint[];
+      points?: ICurvePoint[];
       /**
        * The type of the Shape Path. It can only be set when creating a new ShapePath.
        */
@@ -768,6 +768,14 @@ declare module 'sketch/dom' {
       }
     }
 
+    export interface ICurvePoint {
+      point: IPoint
+      curveFrom: IPoint
+      curveTo: IPoint
+      cornerRadius: number
+      pointType: CurvePoint.PointType
+    }
+
     /**
      * A utility class to represent a curve point (with handles to control the curve in a path).
      */
@@ -804,10 +812,15 @@ declare module 'sketch/dom' {
       }
     }
 
+    export interface IPoint {
+      x: number
+      y: number
+    }
+
     /**
      * A utility class to represent a point.
      */
-    export class Point {
+    export class Point implements IPoint {
       /**
        * The x coordinate of the point.
        */


### PR DESCRIPTION
While preparing the tests for #4 I noticed that it is not possible to create a `ShapePath` without passing in incomplete points. This PR extracts an Interface for Points that can be used during construction. I am not entirely sure which properties are required and which are not. It would probably need to be refined in future.

https://github.com/martinheidegger/sketch-typings-test/blob/ef0f2d50beb1d9db4df9ce86012afbc455fc3e7a/src/my-command.ts#L194-L204