### PR TITLE
fix: add missing path property

### DIFF
--- a/typings/PublicAPI.d.ts
+++ b/typings/PublicAPI.d.ts
@@ -135,6 +135,11 @@ declare module 'sketch/dom' {
        * The unique ID of the document.
        */
       id: string;
+
+      /**
+       * The path to the document (or the appcast URL in case of a Document from a remote Library).
+       */
+      path: string;
       /**
        * The pages of the document.
        */


### PR DESCRIPTION
This small PR adds the missing `path` Property to documents.

see: https://developer.sketch.com/reference/api/#document