### PR TITLE
fix: added missing sharedStyle & sharedStyleId properties.

### DIFF
--- a/typings/PublicAPI.d.ts
+++ b/typings/PublicAPI.d.ts
@@ -472,6 +472,14 @@ declare module 'sketch/dom' {
 
     export class Group extends BaseGroup {
       type: Types.Group;
+      /**
+       * The ID of the SharedStyle or null, identical to sharedStyle.id.
+       */
+      sharedStyleId: string | null;
+      /**
+       * The associated shared style.
+       */
+      sharedStyle: SharedStyle | null;
 
       constructor(properties?: GroupProperties);
     }
@@ -622,6 +630,14 @@ declare module 'sketch/dom' {
        * The actual image of the layer.
        */
       image: ImageData;
+      /**
+       * The ID of the SharedStyle or null, identical to sharedStyle.id.
+       */
+      sharedStyleId: string | null;
+      /**
+       * The associated shared style.
+       */
+      sharedStyle: SharedStyle | null;
 
       constructor(properties?: ImageProperties);
     }
@@ -686,6 +702,14 @@ declare module 'sketch/dom' {
        * The group the Shape is in.
        */
       parent: Group;
+      /**
+       * The ID of the SharedStyle or null, identical to sharedStyle.id.
+       */
+      sharedStyleId: string | null;
+      /**
+       * The associated shared style.
+       */
+      sharedStyle: SharedStyle | null;
 
       constructor(properties?: ShapeProperties);
     }
@@ -743,6 +767,14 @@ declare module 'sketch/dom' {
        * If the Path is closed.
        */
       closed: boolean;
+      /**
+       * The ID of the SharedStyle or null, identical to sharedStyle.id.
+       */
+      sharedStyleId: string | null;
+      /**
+       * The associated shared style.
+       */
+      sharedStyle: SharedStyle | null;
 
       constructor(properties?: ShapePathProperties);
 
@@ -894,6 +926,14 @@ declare module 'sketch/dom' {
        * Whether the layer should have a fixed width or a flexible width.
        */
       fixedWidth: boolean;
+      /**
+       * The ID of the SharedStyle or null, identical to sharedStyle.id.
+       */
+      sharedStyleId: string | null;
+      /**
+       * The associated shared style.
+       */
+      sharedStyle: SharedStyle | null;
 
       constructor(properties?: TextProperties);
 


### PR DESCRIPTION
This PR adds missing `sharedStyle` and `sharedStyleId` properties to `Group`, `Image`, `Shape`, `ShapePath` and `Text` classes as specified in the Documentation.