### PR TITLE
fix: add missing getDefaultLineHeight property.

### DIFF
--- a/typings/PublicAPI.d.ts
+++ b/typings/PublicAPI.d.ts
@@ -1910,6 +1910,11 @@ declare module 'sketch/dom' {
        * The style instance will be updated with the value of the Shared Style.
        */
       syncWithSharedStyle(): void;
+
+      /**
+       * @return A number if the layer is a Text layer or undefined.
+       */
+      getDefaultLineHeight(): number | undefined;
     }
 
     export namespace Style {


### PR DESCRIPTION
This PR adds the missing `getDefaultLineHeight` property to styles.

see: https://developer.sketch.com/reference/api/#get-the-default-line-height